### PR TITLE
infravelo: Add "Kurzinfo" to description

### DIFF
--- a/lib/hierbautberlin/importer/infravelo.ex
+++ b/lib/hierbautberlin/importer/infravelo.ex
@@ -109,7 +109,7 @@ defmodule Hierbautberlin.Importer.Infravelo do
   end
 
 
-  defp extract_description(text) do
+  defp extract_description(item) do
     description = "#{item["description"]}"
 
     #districts = "Bezirke: #{item["districts"] |> Enum.map(&(&1.name)) |> Enum.join(", ") || "-"}"
@@ -117,7 +117,7 @@ defmodule Hierbautberlin.Importer.Infravelo do
     holder = "Vorhabenträger: #{item["holder"] || "-"}"
     owner = "Bauherr: #{item["owner"] || "-"}"
     # year = "Jahr der Umsetzung: #{item["owner"] || "-"}"
-    details = "Projekttyp und Metriken: #{Poison.encode!(Poison.encode!(data))}
+    details = "Projekttyp und Metriken: #{Poison.encode!(Poison.encode!(item["types"]))}
 
     "#{description}\n#{districts}\n#{holder}\n#{owner}\n#{details}"
   end

--- a/lib/hierbautberlin/importer/infravelo.ex
+++ b/lib/hierbautberlin/importer/infravelo.ex
@@ -47,7 +47,7 @@ defmodule Hierbautberlin.Importer.Infravelo do
       external_id: item["id"],
       title: item["title"],
       subtitle: item["subtitle"],
-      description: item["description"],
+      description: extract_description(item),
       url: item["link"],
       state: @state_mapping[item["status"]],
       geo_point: point,
@@ -106,5 +106,19 @@ defmodule Hierbautberlin.Importer.Infravelo do
       _ ->
         nil
     end
+  end
+
+
+  defp extract_description(text) do
+    description = "#{item["description"]}"
+
+    #districts = "Bezirke: #{item["districts"] |> Enum.map(&(&1.name)) |> Enum.join(", ") || "-"}"
+    districts = "Bezirke: #{Poison.encode!(Poison.encode!(data))}
+    holder = "Vorhabenträger: #{item["holder"] || "-"}"
+    owner = "Bauherr: #{item["owner"] || "-"}"
+    # year = "Jahr der Umsetzung: #{item["owner"] || "-"}"
+    details = "Projekttyp und Metriken: #{Poison.encode!(Poison.encode!(data))}
+
+    "#{description}\n#{districts}\n#{holder}\n#{owner}\n#{details}"
   end
 end


### PR DESCRIPTION
Infravelo recently added old projects without any description. The pages look like this

Example: https://www.infravelo.de/projekt/thomasstrasse-55/

<img width="655" alt="image" src="https://github.com/HierBautBerlin/website/assets/111561/d10c921f-74b6-42b4-bd94-cbba804ad5f3">


The most important info is the "Jahr der Umsetzung: 2019" which – unfortunately – is not part of the API response at https://www.infravelo.de/api/v1/project/9080031626/.

I emailed them about this.

Nevertheless, it would be good to have the "Kurzinfo" data part of the description. This is what this PR sketches out. I consider it a draft PR, since I know nothing about Elixir so this may be terrible and broken code :-).

For some of the more nested objects like "Projekttyp und Metriken" I suggest to just stringify the object which is still a lot more useful than having to look at the website for details.